### PR TITLE
[UNTESTED] Static linking on binaries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ build-linux:
   script:
     - apt-get update -y
     - apt-get install yarnpkg libsoup-3.0-0 libsoup-3.0-dev libatk-adaptor libgtk-3-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev -y
+    - export RUSTFLAGS='-C target-feature=+crt-static'
     - yarnpkg
     - yarnpkg tauri build
     - cp src-tauri/target/release/bundle/deb/*.deb .
@@ -20,6 +21,7 @@ build-windows:
   tags:
     - windows
   script:
+    - set RUSTFLAGS=-C target-feature=+crt-static
     - yarn
     - yarn tauri build
     - cp src-tauri/target/release/bundle/nsis/*.exe .

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,3 +54,8 @@ features = ["bin_enc"] # You can also use "yaml_enc" or "bin_enc"
 [dependencies.reqwest]
 version = "0.12"
 features = ["json", "blocking"]
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = 'abort'


### PR DESCRIPTION
### PR Description:

**Prevent Missing OpenSSL Libraries on Windows/Linux (Non-dev Instances)**

This PR modifies the build process to generate statically linked binaries for Windows and Linux. By including OpenSSL in the build and disabling dynamic linking, this ensures that the application can run smoothly on non-dev machines without requiring additional OpenSSL libraries or dependencies.

**Note**: This change is currently untested as I do not have access to the CI environment.