### PR TITLE
Pull the log level from the environment and only show the "Debug Info" settings tab when it's set to DEBUG or the "SHIFT" keybind

### DIFF
--- a/src-tauri/src/debug.rs
+++ b/src-tauri/src/debug.rs
@@ -1,4 +1,5 @@
 use crate::{DATA_ROOT_DIR, DB};
+use log::LevelFilter;
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -7,6 +8,7 @@ pub struct SystemData {
     client_id: String,
     base_url: String,
     data_dir: String,
+    log_level: String,
 }
 
 #[tauri::command]
@@ -16,6 +18,7 @@ pub fn fetch_system_data() -> Result<SystemData, String> {
         client_id: db_handle.auth.as_ref().unwrap().client_id.clone(),
         base_url: db_handle.base_url.clone(),
         data_dir: DATA_ROOT_DIR.lock().unwrap().to_string_lossy().to_string(),
+        log_level: std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()),
     };
     drop(db_handle);
 


### PR DESCRIPTION
Complete chore "Pull the log level from the environment and only show the "Debug Info" settings tab when it's set to DEBUG" with additional functionality by incorporating holding the "Shift" key while clicking app settings in an RUST_LOG state to emulate the same thing.