### PR TITLE
Fix emulator path calculation

### DIFF
--- a/src-tauri/games/src/library.rs
+++ b/src-tauri/games/src/library.rs
@@ -9,7 +9,6 @@ use remote::{
     auth::generate_authorization_header, error::RemoteAccessError, requests::generate_url,
     utils::DROP_CLIENT_ASYNC,
 };
-use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::fs::remove_dir_all;
 use std::thread::spawn;

--- a/src-tauri/process/src/process_manager.rs
+++ b/src-tauri/process/src/process_manager.rs
@@ -371,6 +371,7 @@ impl ProcessManager<'_> {
             let emulator_install_dir = match emulator_game_status {
                 GameDownloadStatus::Installed {
                     install_type: InstalledGameType::Installed,
+                    install_dir,
                     ..
                 } => Ok(install_dir),
                 GameDownloadStatus::Installed {


### PR DESCRIPTION
Fixes a typo that makes the emulator executable append to the **game** install dir, not the **emulator** install dir. 